### PR TITLE
Added highlighting for new tactics

### DIFF
--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -68,7 +68,8 @@
 (defconst jonprl-tactics
   '("cum" "auto" "intro" "elim" "mem-cd" "eq-cd"
     "witness" "hypothesis" "subst" "hyp-subst" "lemma"
-    "unfold" "refine" "assumption" "symmetry")
+    "unfold" "refine" "assumption" "symmetry" "trace"
+    "ext")
   "A list of the tactics to be highlighted in JonPRL mode.")
 
 (defun jonprl-font-lock-defaults ()


### PR DESCRIPTION
There are two new tactics in JonPRL, `trace` and `ext`. In order to give them a proper welcome to the JonPRL family I've added some highlighting for them. Hopefully I did this correctly, it looks good locally.
