### PR TITLE
Add turnstile to pretty symbols

### DIFF
--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -59,7 +59,8 @@
    ("member" . ?∈)
    ("nat" . ?ℕ)
    ("unit" . ?𝟙)
-   ("void" . ?𝟘))
+   ("void" . ?𝟘)
+   ("|-" . ?⊢))
   "Pretty replacement symbols for JonPRL syntax."
   :type '(alist :value-type string :key-type character)
   :group 'jonprl)


### PR DESCRIPTION
This is used in "match goal" expressions, for example:

```
@{ [H : P |- P] => hypothesis <H> }
```
