### PR TITLE
Support for configuration files

### DIFF
--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -37,7 +37,7 @@
 
 (require 'jonprl-compat)
 
-
+
 ;;; Customization options and settings
 
 (defgroup jonprl nil "Customization options for JonPRL"
@@ -201,7 +201,7 @@ If set, this is passed to the JonPRL compilation command instead of the current 
                     jonprl-tactics)))))
     (setq jonprl-tactics tactics-list)))
 
-
+
 ;;; Invoking JonPRL
 
 ;; Compilation mode regexps, to be used for compilation mode
@@ -324,8 +324,7 @@ or nil if not found."
       (message "Press 'q' to close the development.")
       (let ((inhibit-read-only t))
         (erase-buffer)
-        (call-process jonprl-path nil t t command-args))
-      )))
+        (call-process jonprl-path nil t t command-args)))))
 
 (defun jonprl-development-quit ()
   "Exit the development buffer."
@@ -333,7 +332,7 @@ or nil if not found."
   (let ((buffer (get-buffer jonprl-development-buffer-name)))
     (when (and buffer (buffer-live-p buffer)) (kill-buffer buffer))))
 
-
+
 ;;; ElDoc
 
 (defun jonprl-eldoc-function ()
@@ -353,7 +352,7 @@ or nil if not found."
           (t nil))))
 
 
-
+
 ;;; yasnippet integration
 
 (defun jonprl-snippet-escape (string)
@@ -433,7 +432,7 @@ natural number."
       (jonprl-define-snippets operators)
       (setq jonprl-operators operators))))
 
-
+
 ;;; Means of invoking commands: tool bar and keybindings
 
 (defvar jonprl-mode-path nil
@@ -466,7 +465,7 @@ Lisp package.")
       t)
     map))
 
-
+
 ;;; Syntax table
 
 (defvar jonprl-mode-syntax-table
@@ -482,7 +481,7 @@ Lisp package.")
     (modify-syntax-entry ?\) ")(4n" table)
     table))
 
-
+
 ;;; Standard completion
 
 (defun jonprl-complete-at-point ()
@@ -497,7 +496,7 @@ Lisp package.")
                                                  (mapcar #'car jonprl-operators)))))
       (if (null candidates) () (list start end candidates)))))
 
-
+
 ;;; Menus
 (easy-menu-define jonprl-mode-menu jonprl-mode-map
   "Menu for JonPRL major mode"
@@ -505,7 +504,7 @@ Lisp package.")
     ["Check" jonprl-check-buffer t]
     ["Print development" jonprl-print-development t]))
 
-
+
 ;;; The mode itself
 
 (defun jonprl-mode-run-after-save-hook ()

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -275,13 +275,14 @@ arguments."
 (defun jonprl-read-configuration-file ()
   (let ((cfg-prompt "Set configuration file:")
         (cfg-default (jonprl-find-file-upwards "cfg")))
-    (if cfg-default
-      (read-file-name cfg-prompt
-                      (file-name-directory (car cfg-default))
-                      (car cfg-default)
-                      t
-                      (file-name-nondirectory (car cfg-default)))
-      (read-file-name cfg-prompt nil nil nil t))))
+    (expand-file-name
+      (if cfg-default
+        (read-file-name cfg-prompt
+                        (file-name-directory (car cfg-default))
+                        (car cfg-default)
+                        t
+                        (file-name-nondirectory (car cfg-default)))
+        (read-file-name cfg-prompt nil nil nil t)))))
 
 (defun jonprl-set-configuration-file (filename)
   "Choose a configuration file for your JonPRL development"

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -226,7 +226,7 @@ or nil if not found."
       ((find-file-r (path)
                     (let* ((parent (file-name-directory path))
                            (matching (if parent
-                                         (jonprl-try-directory-files parent t (concat suffix "$"))
+                                         (ignore-errors (directory-files parent t (concat suffix "$")))
                                        nil)))
                       (cond
                        (matching matching)
@@ -242,21 +242,6 @@ or nil if not found."
                           (and (not allow-hidden)
                                (string-prefix-p "." (file-name-nondirectory f))))
                       (find-file-r dir))))))
-
-;; The following code is cribbed from idris-ipkg-mode
-(defun jonprl-try-directory-files (directory &optional full match nosort)
-  "Call `directory-files' with arguments DIRECTORY, FULL, MATCH,
-and NOSORT, but return the empty list on failure instead of
-throwing an error.
-See the docstring for `directory-files' for the meaning of the
-arguments."
-  ;; This wrapper is useful because some users can't read all the
-  ;; directories above the current working directory. In particular,
-  ;; /home is sometimes not readable.
-  (condition-case nil
-      (directory-files directory full match nosort)
-    (error nil)))
-
 
 (defun jonprl-command-args (should-print)
   (let* ((filename (buffer-file-name))

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -213,15 +213,25 @@ If set, this is passed to the JonPRL compilation command instead of the current 
   "\\[\\(?1:\\(?2:[^:]+\\):\\(?3:[0-9]+\\)\\.\\(?4:[0-9]+\\)-\\(?5:[0-9]+\\)\\.\\(?6:[0-9]+\\)\\)\\]: tactic '\\(?7:.+\\)' failed with goal:"
   "Regexp matching JonPRL tactic failures.")
 
-
 (defun jonprl-command-args (should-print)
   (let* ((filename (buffer-file-name))
          (file (file-name-nondirectory filename))
          (config-file jonprl-configuration-file))
     (concat
      (if (not should-print) "--check " "")
-       (if config-file config-file file))))
+       (if (or (not config-file) (equal config-file 'shut-up)) file config-file))))
 
+(defun jonprl-forget-configuration ()
+  "Forgets the configuration file"
+  (interactive)
+  (setq jonprl-configuration-file nil)
+  (message "Configuration file unset"))
+
+(defun jonprl-set-configuration-file (filename)
+  "Choose a configuration file for your JonPRL development"
+  (interactive (list (read-file-name "Set configuration file:")))
+  (setq jonprl-configuration-file filename)
+  (message (concat "Configuration file set to " filename)))
 
 (defun jonprl-check-buffer ()
   "Load the current file into JonPRL."

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -244,6 +244,9 @@ or nil if not found."
                       (find-file-r dir))))))
 
 (defun jonprl-command-args (should-print)
+  "Compute the arguments to be passed to JonPRL, based on the (optional)
+  configuration tile. The development will be checked silently unless
+  'should-print' is true."
   (let* ((filename (buffer-file-name))
          (file (file-name-nondirectory filename))
          (config-file jonprl-configuration-file))
@@ -252,12 +255,14 @@ or nil if not found."
        (if (or (not config-file) (equal config-file 'shut-up)) file config-file))))
 
 (defun jonprl-forget-configuration ()
-  "Forgets the configuration file"
+  "Forget the configuration file"
   (interactive)
   (setq jonprl-configuration-file nil)
   (message "Configuration file unset"))
 
 (defun jonprl-read-configuration-file ()
+  "Prompt the user for a configuration file, prepopulating with a .cfg file in
+  the current directory or above, if possible."
   (let ((cfg-prompt "Set configuration file:")
         (cfg-default (jonprl-find-file-upwards "cfg")))
     (expand-file-name
@@ -276,6 +281,7 @@ or nil if not found."
   (message (concat "Configuration file set to " filename)))
 
 (defun jonprl-initialize-configuration ()
+  "Check if a configuration file is loaded, and if not, prompt the user to choose one."
   (interactive)
   (unless jonprl-configuration-file
     (if (y-or-n-p "Do you want to choose a .cfg file?")

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -85,11 +85,11 @@ manually."
   :group 'jonprl
   :options '(jonprl-update-operators))
 
-(defcustom jonprl-pre-check-buffer-hook '(save-buffer)
+(defcustom jonprl-pre-check-buffer-hook '(save-buffer jonprl-initialize-configuration)
   "A hook to run prior to checking the buffer."
   :type 'hook
   :group 'jonprl
-  :options '(save-buffer))
+  :options '(save-buffer jonprl-initialize-configuration))
 
 (defface jonprl-keyword-face '((t (:inherit font-lock-keyword-face)))
   "The face used to highlight JonPRL keywords."
@@ -232,6 +232,13 @@ If set, this is passed to the JonPRL compilation command instead of the current 
   (interactive (list (read-file-name "Set configuration file:")))
   (setq jonprl-configuration-file filename)
   (message (concat "Configuration file set to " filename)))
+
+(defun jonprl-initialize-configuration ()
+  (interactive)
+  (unless jonprl-configuration-file
+    (if (y-or-n-p "Do you want to choose a .cfg file?")
+      (jonprl-set-configuration-file (read-file-name "Set configuration file:"))
+      (setq jonprl-configuration-file 'shut-up))))
 
 (defun jonprl-check-buffer ()
   "Load the current file into JonPRL."

--- a/jonprl-mode.el
+++ b/jonprl-mode.el
@@ -85,11 +85,11 @@ manually."
   :group 'jonprl
   :options '(jonprl-update-operators))
 
-(defcustom jonprl-pre-check-buffer-hook '(save-buffer jonprl-initialize-configuration)
+(defcustom jonprl-pre-check-buffer-hook '(save-buffer)
   "A hook to run prior to checking the buffer."
   :type 'hook
   :group 'jonprl
-  :options '(save-buffer jonprl-initialize-configuration))
+  :options '(save-buffer))
 
 (defface jonprl-keyword-face '((t (:inherit font-lock-keyword-face)))
   "The face used to highlight JonPRL keywords."
@@ -301,6 +301,7 @@ arguments."
   "Load the current file into JonPRL."
   (interactive)
   (run-hooks 'jonprl-pre-check-buffer-hook)
+  (jonprl-initialize-configuration)
   (let* ((filename (buffer-file-name))
          (dir (file-name-directory filename))
          (command (concat jonprl-path " " (jonprl-command-args nil)))


### PR DESCRIPTION
To resolve #26 

This PR differs in a few ways from the proposal. Mainly, I wasn't able to figure out how to respond to the user cancelling out of the minibuffer when I call `read-file-name`—so instead, I have it ask the user whether or not they wish to specify a configuration file. If so, then `read-file-name` is called, prepopulated with whatever `.cfg` file it could find looking up the file tree (thanks for that snippet, btw!); otherwise, the configuration file variable is set to `shut-up`.

Otherwise, this implementation should comport with the proposal. However, I am not that good at writing Emacs Lisp, so I won't feel bad if you think the code is crap and don't want to merge it :wink: 
